### PR TITLE
Hsts hotfix

### DIFF
--- a/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
+++ b/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
@@ -430,7 +430,7 @@ to be displayed in place of a error stack trace. -->
           <conditions>
             <add input="{HTTPS}" pattern="on" ignoreCase="true" />
           </conditions>
-          <action type="Rewrite" value="max-age=31536000; preload" />
+          <action type="Rewrite" value="max-age=31536000; includeSubDomains; preload" />
         </rule>
         <rule name="Cache Static Types" enabled="true">
           <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />

--- a/tools/build/scripts/github-release.ps1
+++ b/tools/build/scripts/github-release.ps1
@@ -79,6 +79,10 @@ function GitHub-Release($tagname, $releaseName, $commitId, $IsPreRelease, $relea
 
     #>
 
+    # GitHub has deprecated TLS v1 and v1.1 as of 2/22/2018: https://githubengineering.com/crypto-removal-notice/
+    # This sets PowerShell to use TLS v1.2
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+
     $draft = $FALSE
 
     $releaseData = @{


### PR DESCRIPTION
Update web.config HSTS attributes to have includeSubDomains. Also included change to use TLS1.2 in the github-release PS script.

These changes were deployed to PROD Live and Preview on 3/13/2018.