### PR TITLE
Send fatal errors to PROD app alerts address

### DIFF
--- a/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.COLO-Live.config
+++ b/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.COLO-Live.config
@@ -89,6 +89,21 @@
     </web>
   </nci>
 
+  <common>
+    <logging xdt:Transform="Replace">
+      <factoryAdapter type="NCI.Logging.Factories.MultiLoggerFactoryAdapter, NCILibrary.Core">
+        <arg key="EmailLogger.factoryAdapter" value="NCI.Logging.Factories.EmailLoggerFactoryAdapter, NCILibrary.Core" />
+        <arg key="EmailLogger.level" value="FATAL" />
+        <arg key="EmailLogger.emailAddressFrom" value="${APP_ALERT_EMAIL}"/>
+        <arg key="EmailLogger.emailAddressesTo" value="${APP_ALERT_EMAIL}"/>
+
+        <arg key="EventLogger.factoryAdapter" value="NCI.Logging.Factories.EventLoggerFactoryAdapter, NCILibrary.Core" />
+        <arg key="EventLogger.level" value="ERROR" />
+        <arg key="EventLogger.logSource" value="CDE_CancerGov" />
+      </factoryAdapter>
+    </logging>
+  </common>
+
   <location>
     <system.web>
       <!--


### PR DESCRIPTION
Colo is a production system but was mistakenly sending fatal errors to
the test address instead of one which is monitored.