### PR TITLE
OCECTS-849: Removing files for EVS and friendly name mapping updates.

### DIFF
--- a/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
+++ b/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
@@ -113,7 +113,6 @@
           <add name="EvsMapping" priority="1" filePath="~/PublishedContent/Files/Configuration/clinical-trials/EVSMapping.txt" errOnDuplicates="true" />
           <add name="OverrideMapping" priority="1" filePath="~/PublishedContent/Files/Configuration/clinical-trials/OverrideMapping.txt" />
           <add name="TokensMapping" priority="1" filePath="~/PublishedContent/Files/Configuration/clinical-trials/TokensMapping.txt" />
-          <add name="StagesMapping" priority="1" filePath="~/PublishedContent/Files/Configuration/clinical-trials/StagesMapping.txt" />
         </termMappingFiles>
       </basicClinicalTrialSearchAPI>
       <bestbets pathConfigurationClass="CancerGov.Search.BestBets.CancerGovBestBetsPathConfiguration, CancerGov.Search.BestBets" reindexSchedule="0 5 4,9,13,18,23 ? * MON-FRI" />


### PR DESCRIPTION
- Remove StagesMapping from BasicClinicalTrialSearchAPI section as it is no longer needed.

Merging DLP EVS Hotfix after release on 8/8/2018.