### PR TITLE
Adding required closing tag.

### DIFF
--- a/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
+++ b/CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
@@ -151,6 +151,7 @@
               <field name="metatag.description" />
               <field name="metatag.dcterms.type" />
             </fields>
+          </siteWideSearchCollection>
 
           <siteWideSearchCollection name="NCIConnectionSearch" template="docSearch" index="cgov" site="www.cancer.gov/nci/rare-brain-spine-tumor" cluster="SearchCluster">
             <fields>


### PR DESCRIPTION
These changes were made for a file-deployment-only release for NCI Connect on 09-17-2018, and the closing tag was missed when making the changes in the repository. There is no release tag associated with this change.